### PR TITLE
Add 요리보기 page

### DIFF
--- a/recipick_vue/src/components/Dish.vue
+++ b/recipick_vue/src/components/Dish.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="dish-item">
+    <div class="post-header">
+      <div class="profile"></div>
+        <span class="profile-name">{{ dish.user.nick_name }} - </span>
+        <span class="profile-name" v-if="dish.user.level">{{ dish.user.level }}</span>
+        <span class="profile-name" v-else>초보 요리사</span>
+      </div>
+    <div class="post-body" :style="{ backgroundImage: `url(${dish.image})` }"></div>
+    <div class="post-content">
+      <p><strong>{{ dish.name }}</strong></p>
+      <p>{{ dish.likes_count }} Likes {{ dish.dislikes_count }} NGs</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+    name: 'DishComponent',
+    props: {
+        dish: {},
+    }
+}
+</script>
+
+<style scoped>
+.profile {
+  background-image: url("https://picsum.photos/100?random=0");
+  width: 30px;
+  height: 30px;
+  background-size: 100%;
+  border-radius: 50%;
+  float: left;
+}
+
+.profile-name {
+  display: block;
+  float: left;
+  padding-left: 10px;
+  padding-top: 7px;
+  font-size: 14px;
+}
+
+.post-header {
+  height: 30px;
+  padding: 10px;
+}
+
+.post-body {
+  height: 150px;
+  background-position: center;
+  background-size: cover;
+}
+
+.post-content {
+  padding-left: 15px;
+  padding-right: 15px;
+  font-size: 14px;
+}
+</style>

--- a/recipick_vue/src/components/Header.vue
+++ b/recipick_vue/src/components/Header.vue
@@ -8,7 +8,9 @@
     </div>
     <div class="header">
         <div class="header-logo">
-            <img src="@/assets/recipick1.png">
+            <router-link to="/main">
+                <img src="@/assets/recipick1.png">
+            </router-link>
         </div>
         <div class="header-right">
             <a href="">레시피 업로드</a>
@@ -20,7 +22,7 @@
         <div class="container">
             <ul class="nav-menu">
             <li>카테고리</li>
-            <li><a href="#">요리보기</a></li>
+            <li><router-link to="/dish-list">요리보기</router-link></li>
             <li><a href="#">재료 무료 나눔</a></li>
             <li><a href="#">요리 실험 일지</a></li>
             <li><a href="#">요리 지식인</a></li>

--- a/recipick_vue/src/router/index.js
+++ b/recipick_vue/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import LoginAccount from '../views/LoginAccountView.vue';
 import Mainpage from '@/views/MainView.vue';
 import store from '@/store';
+import DishList from '@/views/DishListView.vue';
 
 const routes = [
   {
@@ -20,6 +21,14 @@ const routes = [
     path: '/main',
     name: 'main',
     component: Mainpage,
+    meta: {
+      requireLogin: true
+    }
+  },
+  {
+    path: '/dish-list',
+    name: 'DishList',
+    component: DishList,
     meta: {
       requireLogin: true
     }

--- a/recipick_vue/src/store/index.js
+++ b/recipick_vue/src/store/index.js
@@ -5,6 +5,7 @@ export default createStore({
     isAuthenticated: false,
     token: '',
     id: '',
+    isLoading: false
   },
   getters: {
   },
@@ -21,6 +22,9 @@ export default createStore({
       state.isAuthenticated = false;
       state.id = '';
     },
+    setIsLoading(state, status) {
+      state.isLoading = status
+    }
   },
   actions: {
   },

--- a/recipick_vue/src/views/DishListView.vue
+++ b/recipick_vue/src/views/DishListView.vue
@@ -1,0 +1,80 @@
+<template>
+<div class="dish-container">
+    <div class="dish-grid">
+        <div v-for="dish in dishList" :key="dish.id" class="post">
+            <Dish :dish="dish"/>
+        </div>
+    </div>
+</div>
+</template>
+
+<script>
+import apiClient from '@/store/api';
+import Dish from '@/components/Dish.vue';
+
+export default {
+    name: 'DishListView',
+    data() {
+        return {
+            dishList: [],
+        }
+    },
+    mounted() {
+        this.getDishList()
+    },
+    methods: {
+        async getDishList() {
+            try {
+                const response = await apiClient.get('/recipes/?all=true')
+                this.dishList = response.data;
+                document.title = '요리보기 - Recipick';
+            } catch (error) {
+                console.log(error);
+            }
+        }
+    },
+    components: {
+        Dish: Dish,
+    }
+}
+</script>
+
+<style>
+.dish-container {
+  padding: 20px;
+}
+
+.dish-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2vw;
+  padding: 2vw;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.post {
+  width: 100%;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 1024px) {
+  .dish-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .dish-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .dish-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
새로 추가한 내용
 - 메인로고 누르면 main화면으로 이동
 - 카테고리에서 요리보기 누르면 /dish-list에서 db에 있는 모든 요리 보여주는 페이지로 이동
 - 웹페이지 상단바에 기존 recipick_django로 보이는 이름을 요리보기 - Recipick으로 변경
 - 로그인이 안되면 로그인 페이지에서 해당 페이지로 접근 불가