### PR TITLE
무료나눔페이지 만들었습니다.

### DIFF
--- a/recipick_app/freemarket/serializers.py
+++ b/recipick_app/freemarket/serializers.py
@@ -1,6 +1,8 @@
 """
 Serializers for freemarket APIs.
 """
+from django.utils import timezone
+
 from rest_framework import serializers
 
 from recipe.serializers import (
@@ -14,6 +16,7 @@ from freemarket.models import Freemarket
 class FreemarketListSerializer(serializers.ModelSerializer):
     """자유시장 List view을 위한 serializer"""
     user = NicknameSerializer(read_only=True)
+    days_ago = serializers.SerializerMethodField()
 
     class Meta:
         model = Freemarket
@@ -23,8 +26,21 @@ class FreemarketListSerializer(serializers.ModelSerializer):
             'name',
             'image',
             'is_shared',
+            'days_ago',
         ]
         read_only_fields = ['id']
+
+    def get_days_ago(self, obj):
+        """현재 날짜와 수정일자의 차이를 계산하고 return"""
+        today = timezone.localdate()
+        diff_days = (today-obj.modify_dt).days
+
+        if diff_days == 0:
+            return "오늘"
+        elif diff_days == 1:
+            return "하루 전"
+        else:
+            return f'{diff_days}일 전'
 
 
 class FreemarketSerializer(FreemarketListSerializer):

--- a/recipick_vue/src/components/Header.vue
+++ b/recipick_vue/src/components/Header.vue
@@ -43,7 +43,7 @@
                     </ul>
                 </div>
                 <li><router-link to="/recipe-list">요리보기</router-link></li>
-                <li><a href="#">재료 무료 나눔</a></li>
+                <li><router-link to="/freemarket">재료 무료 나눔</router-link></li>
                 <li><a href="#">요리 실험 일지</a></li>
                 <li><a href="#">요리 지식인</a></li>
                 <li><a href="#">유통기한 알림</a></li>

--- a/recipick_vue/src/components/MarketBox.vue
+++ b/recipick_vue/src/components/MarketBox.vue
@@ -1,0 +1,70 @@
+<template>
+    <div class="dish-item">
+      <router-link :to="'/freemarket/' + market.id">
+        <div class="post-header">
+          <div class="profile"></div>
+            <span class="profile-name">{{ market.user.nick_name }} - </span>
+            <span class="profile-name">{{ market.user.level }}</span>
+          </div>
+        <div class="post-body" :style="{ backgroundImage: `url(${market.image})` }"></div>
+        <div class="post-content">
+          <p class="text-center fs-6"><strong>{{ market.name }}</strong></p>
+          <p class="text-center"><strong>지역명 / {{ market.days_ago }}</strong></p>
+          <div class="text-center fs-5">
+            <p v-if="market.is_shared === false"><strong>무료 나눔</strong></p>
+            <p v-else><strong>나눔 완료</strong></p>
+          </div>
+        </div>
+      </router-link>
+    </div>
+  </template>
+
+  <script>
+  export default {
+      name: 'MarketComponent',
+      props: {
+          market: {},
+      }
+  }
+  </script>
+
+  <style scoped>
+  .profile {
+    background-image: url("https://picsum.photos/100?random=0");
+    width: 30px;
+    height: 30px;
+    background-size: 100%;
+    border-radius: 50%;
+    float: left;
+  }
+
+  .profile-name {
+    display: block;
+    float: left;
+    padding-left: 10px;
+    padding-top: 7px;
+    font-size: 14px;
+  }
+
+  .post-header {
+    height: 45px;
+    padding: 10px;
+  }
+
+  .post-body {
+    height: 150px;
+    background-position: center;
+    background-size: cover;
+  }
+
+  .post-content {
+    padding-left: 15px;
+    padding-right: 15px;
+    font-size: 14px;
+  }
+
+  .dish-item a {
+    text-decoration: none;
+    color: black;
+  }
+  </style>

--- a/recipick_vue/src/components/ProfileHeader.vue
+++ b/recipick_vue/src/components/ProfileHeader.vue
@@ -1,0 +1,45 @@
+<template>
+    <div>
+        <div class="profile-container">
+            <div class="profile"></div>
+            <div class="name-container">
+                <span class="profile-name">{{ user.nick_name }} - </span>
+                <span class="profile-name">{{ user.level }}</span>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ProfileHeader',
+    props: {
+        user: {}
+    }
+}
+</script>
+
+<style>
+.profile-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.profile {
+    background-image: url("https://picsum.photos/100?random=0");
+    width: 50px;
+    height: 50px;
+    background-size: 100%;
+    border-radius: 50%;
+}
+
+.name-container {
+    display: flex;
+    margin-left: 15px;
+}
+
+.profile-name {
+    font-size: 20px;
+}
+</style>

--- a/recipick_vue/src/router/index.js
+++ b/recipick_vue/src/router/index.js
@@ -7,6 +7,9 @@ import RecipeDetail from '@/views/RecipeDetail.vue';
 import Signup from '@/views/SignupView.vue';
 import Mypage from '@/views/MypageView.vue';
 import Update from '@/views/UpdateView.vue';
+import FreeMarket from '@/views/FreeMarketView.vue';
+import MarketDetail from '@/views/MarketDetailVIew.vue';
+
 
 const routes = [
   {
@@ -33,6 +36,22 @@ const routes = [
     path: '/recipe-list',
     name: 'RecipeList',
     component: RecipeList,
+    meta: {
+      requireLogin: true
+    }
+  },
+  {
+    path: '/freemarket',
+    name: 'FreeMarket',
+    component: FreeMarket,
+    meta: {
+      requireLogin: true
+    }
+  },
+  {
+    path: '/freemarket/:market_id/',
+    name: 'MarketDetail',
+    component: MarketDetail,
     meta: {
       requireLogin: true
     }

--- a/recipick_vue/src/views/FreeMarketView.vue
+++ b/recipick_vue/src/views/FreeMarketView.vue
@@ -1,0 +1,80 @@
+<template>
+<div class="dish-container">
+    <div class="dish-grid">
+        <div v-for="market in marketList" :key="market.id" class="post">
+            <MarketBox :market="market"/>
+        </div>
+    </div>
+</div>
+</template>
+
+<script>
+import apiClient from '@/store/api';
+import MarketBox from '@/components//MarketBox.vue';
+
+export default {
+    name: 'FreeMarketView',
+    data() {
+        return {
+            marketList: [],
+        }
+    },
+    mounted() {
+        this.getMarketList()
+    },
+    methods: {
+        async getMarketList() {
+            try {
+                const response = await apiClient.get('/freemarkets/?all=true')
+                this.marketList = response.data;
+                document.title = '재료 무료나눔 - Recipick';
+            } catch (error) {
+                console.log(error);
+            }
+        }
+    },
+    components: {
+        MarketBox: MarketBox,
+    }
+}
+</script>
+
+<style>
+.dish-container {
+  padding: 20px;
+}
+
+.dish-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2vw;
+  padding: 2vw;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.post {
+  width: 100%;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 1024px) {
+  .dish-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .dish-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .dish-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/recipick_vue/src/views/LoginAccountView.vue
+++ b/recipick_vue/src/views/LoginAccountView.vue
@@ -34,11 +34,13 @@ export default {
   align-items: center;
   width: 100%;
 }
+
 .logo-image img {
   margin-top: 30px;
   max-width: 250px;
   height: auto;
 }
+
 /* 컨테이너 스타일 */
 .container {
   display: flex;
@@ -51,6 +53,7 @@ export default {
   background-color: white;
   padding: 20px;
 }
+
 /* 왼쪽 */
 .left-section {
   flex: 1;
@@ -59,9 +62,11 @@ export default {
   justify-content: center;
   align-items: center;
 }
-.left-section img{
+
+.left-section img {
   width: 100%;
 }
+
 /* 오른쪽 */
 .right-section {
   flex: 1;

--- a/recipick_vue/src/views/MainView.vue
+++ b/recipick_vue/src/views/MainView.vue
@@ -11,9 +11,11 @@
 
     <div class="slider-container">
         <div class="slider">
-            <div class="slide" v-for="(image, i) in banners" :key="i"
+            <div class="slide" v-for="(banner, i) in banners" :key="i"
                 :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
-                <img :src="image" alt="배너 이미지" />
+                <router-link :to="banner.link">
+                    <img :src="banner.image" alt="배너 이미지" />
+                </router-link>
             </div>
         </div>
         <button class="prev" @click="prevSlide">〈</button>
@@ -80,13 +82,27 @@ import apiClient from '@/store/api';
 export default {
     data() {
         return {
-            // Recipick의 메뉴 알기
             banners: [
-                require('@/assets/banner1.png'),
-                require('@/assets/banner2.png'),
-                require('@/assets/banner3.png'),
-                require('@/assets/banner4.png'),
-                require('@/assets/banner5.png'),
+                {
+                    image: require('@/assets/banner1.png'),
+                    link: '/freemarket'
+                },
+                {
+                    image: require('@/assets/banner2.png'),
+                    link: '/#'
+                },
+                {
+                    image: require('@/assets/banner3.png'),
+                    link: '/#'
+                },
+                {
+                    image: require('@/assets/banner4.png'),
+                    link: '/#'
+                },
+                {
+                    image: require('@/assets/banner5.png'),
+                    link: '/#'
+                },
             ],
             currentIndex: 0,
             intervalId: null,

--- a/recipick_vue/src/views/MarketDetailVIew.vue
+++ b/recipick_vue/src/views/MarketDetailVIew.vue
@@ -1,0 +1,163 @@
+<template>
+
+  <body>
+    <div v-if="market" class="dish-detail mb-5">
+      <div class="row">
+        <div class="col-md-8">
+          <figure class="mb-4 dish-image">
+            <img v-bind:src="market.image" class="img-fluid">
+          </figure>
+        </div>
+        <div class="col-md-4">
+          <ProfileHeader :user="market.user" />
+          <h1 class="title"><strong>{{ market.name }}</strong></h1>
+
+          <h2 class="subtitle">Information</h2>
+          <p><strong>{{ market.count }} 개</strong></p>
+          <p><strong>획득일자: {{ market.purchase_dt }}</strong></p>
+          <p><strong>업로드: {{ market.days_ago }}</strong></p>
+          <p v-if="!market.is_shared"><strong>상태: 무료나눔중</strong></p>
+          <p v-else><strong>상태: 나눔완료</strong></p>
+          <div class="mt-4">
+            <button v-if="isAuthor && !market.is_shared" @click="handleComplete"
+              class="btn btn-warning me-2">나눔완료</button>
+            <button v-if="isAuthor && !market.is_shared" @click="handleEdit" class="btn btn-primary me-2">수정하기</button>
+            <button v-if="isAuthor" @click="handleDelete" class="btn btn-danger">삭제하기</button>
+            <button v-if="!isAuthor && !market.is_shared" @click="handleContact" class="btn btn-success">연락하기</button>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h2 class="subtitle">Description</h2>
+        {{ market.description }}
+        <div class="toast-container position-fixed bottom-0 end-0 p-3">
+          <div class="toast align-items-center text-white border-0" :class="toastClass" role="alert"
+            aria-live="assertive" aria-atomic="true" ref="toast">
+            <div class="d-flex">
+              <div class="toast-body">
+                {{ toastMessage }}
+              </div>
+              <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+                aria-label="Close"></button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</template>
+
+<script>
+import apiClient from '@/store/api';
+import ProfileHeader from '@/components/ProfileHeader.vue';
+
+export default {
+  name: "MarketDetailView",
+  data() {
+    return {
+      market: null,
+      currentUser: null,
+    }
+  },
+  computed: {
+    isAuthor() {
+      return this.currentUser && this.market && this.currentUser.nick_name === this.market.user.nick_name;
+    }
+  },
+  methods: {
+    async fetchMarketData() {
+      try {
+        const response = await apiClient.get(`/freemarkets/${this.$route.params.market_id}/`);
+        this.market = response.data;
+        document.title = `${this.market.name} - Recipick`;
+      } catch (error) {
+        console.error('데이터를 불러오는데 실패했습니다:', error);
+      }
+    },
+    async getCurrentUser() {
+      try {
+        const response = await apiClient.get('/user/mypage/me/');
+        this.currentUser = response.data;
+      } catch (error) {
+        console.error('사용자 정보를 불러오는데 실패했습니다:', error);
+      }
+    },
+    async handleComplete() {
+      if (confirm('판매완료 처리하시겠습니까? 이후에 수정은 불가합니다.')) {
+        try {
+          await apiClient.patch(`/freemarkets/${this.market.id}/`, {
+            is_shared: true
+          });
+          this.market.is_shared = true;
+        } catch (error) {
+          console.error('판매완료 처리에 실패했습니다:', error);
+        }
+      }
+    },
+    handleEdit() {
+      this.$router.push(`/market/${this.market.id}/edit`);
+    },
+    async handleDelete() {
+      if (confirm('정말로 삭제하시겠습니까?')) {
+        try {
+          await apiClient.delete(`/freemarkets/${this.market.id}/`);
+
+          this.$router.push('/market');
+        } catch (error) {
+          this.showToast('삭제에 실패했습니다.', 'error');
+        }
+      }
+    },
+    handleContact() {
+      window.location.href = `mailto:${this.market.user_email}`;
+    }
+  },
+  created() {
+    this.fetchMarketData();
+    this.getCurrentUser();
+  },
+  components: {
+    ProfileHeader: ProfileHeader,
+  }
+}
+</script>
+
+<style scoped>
+.dish-detail {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.dish-image {
+  margin: 0;
+}
+
+.dish-image img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.dish-info {
+  margin-top: 20px;
+}
+
+h2 {
+  margin-bottom: 20px;
+}
+
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+li {
+  margin-bottom: 8px;
+}
+
+.btn {
+  padding: 8px 16px;
+  font-size: 14px;
+}
+</style>

--- a/recipick_vue/src/views/RecipeDetail.vue
+++ b/recipick_vue/src/views/RecipeDetail.vue
@@ -1,64 +1,61 @@
 <template>
   <div v-if="dish" class="dish-detail mb-5">
     <div class="row">
-        <div class="col-md-8">
-            <figure class="mb-4 dish-image">
-                <img v-bind:src="dish.image" class="img-fluid">
-            </figure>
-        </div>
-        <div class="col-md-4">
-            <h1 class="title"><strong>{{ dish.name }}</strong></h1>
-            <p><strong>카테고리: </strong>{{ dish.category }}</p>
+      <div class="col-md-8">
+        <figure class="mb-4 dish-image">
+          <img v-bind:src="dish.image" class="img-fluid">
+        </figure>
+      </div>
+      <div class="col-md-4">
+        <ProfileHeader :user="dish.user"/>
+        <h1 class="title"><strong>{{ dish.name }}</strong></h1>
+        <p><strong>카테고리: </strong>{{ dish.category }}</p>
 
-            <h2 class="subtitle">Information</h2>
-            <h4>재료: </h4>
-            <p>
-                {{ dish.ingredients.map(ing => ing.name).join(', ') }}
-            </p>
-            <p><strong>{{ dish.serving }} 인분</strong></p>
-            <p><strong>요리시간: {{ dish.time_minutes }}</strong></p>
-            <p>
-                <strong v-if="dish.link">참고링크: {{ dish.link }}</strong>
-                <strong v-else>참고링크: 없음</strong>
-            </p>
+        <h2 class="subtitle">Information</h2>
+        <h4>재료: </h4>
+        <p>
+          {{ dish.ingredients.map(ing => ing.name).join(', ') }}
+        </p>
+        <p><strong>{{ dish.serving }} 인분</strong></p>
+        <p><strong>요리시간: {{ dish.time_minutes }}</strong></p>
+        <p>
+          <strong v-if="dish.link">참고링크: {{ dish.link }}</strong>
+          <strong v-else>참고링크: 없음</strong>
+        </p>
 
-            <div class="mt-4">
-                <button @click="handleLike" class="btn btn-success me-2">
-                    👍 좋아요 ({{ dish.likes_count }})
-                </button>
-                <button @click="handleDislike" class="btn btn-danger">
-                    👎 싫어요 ({{ dish.dislikes_count }})
-                </button>
-            </div>
+        <div class="mt-4">
+          <button @click="handleLike" class="btn btn-success me-2">
+            👍 좋아요 ({{ dish.likes_count }})
+          </button>
+          <button @click="handleDislike" class="btn btn-danger">
+            👎 싫어요 ({{ dish.dislikes_count }})
+          </button>
         </div>
+      </div>
     </div>
     <div>
-        <h2 class="subtitle">Description</h2>
-        {{ dish.description }}
-        {{ cur }}
-        <div class="toast-container position-fixed bottom-0 end-0 p-3">
-            <div
-            class="toast align-items-center text-white border-0"
-            :class="toastClass"
-            role="alert"
-            aria-live="assertive"
-            aria-atomic="true"
-            ref="toast"
-            >
-            <div class="d-flex">
-                <div class="toast-body">
-                {{ toastMessage }}
-                </div>
-                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      <h2 class="subtitle">Description</h2>
+      {{ dish.description }}
+      {{ cur }}
+      <div class="toast-container position-fixed bottom-0 end-0 p-3">
+        <div class="toast align-items-center text-white border-0" :class="toastClass" role="alert" aria-live="assertive"
+          aria-atomic="true" ref="toast">
+          <div class="d-flex">
+            <div class="toast-body">
+              {{ toastMessage }}
             </div>
-            </div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+              aria-label="Close"></button>
+          </div>
         </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import apiClient from '@/store/api';
+import ProfileHeader from '@/components/ProfileHeader.vue';
 import { Toast } from 'bootstrap';
 
 export default {
@@ -133,6 +130,9 @@ export default {
   },
   created() {
     this.fetchDishData();
+  },
+  components: {
+    ProfileHeader: ProfileHeader,
   }
 }
 </script>


### PR DESCRIPTION
*업데이트 내용*
 - 메인 페이지에서 무료나눔 배너를 누르면 해당 페이지로 이동
 - 추후 MainVIew.vue에 /# <- 이거 수정하면 해당 이미지에 링크를 부여할 수 있도록 구현
 - 무료나눔페이지 & 무료나눔 상세페이지 구현
 - 요리보기 상세 & 무료나눔 상세의 오른쪽 상단에 유저의 사진과 닉네임 칭호가 나오도록 구현
 - 상세페이지 오른쪽 상단 유저의 프로필정보칸은 자주 사용될 것 같아서 ProfileHeader.vue로 component화 시킴
 - 상세페이지에서 자신이 만든 마켓인 경우, 나눔완료 & 수정 & 삭제 버튼 생성
 - 상세페이지에서 다른사람이 만든 마켓인 경우, 연락하기 버튼 생성
 - 나눔하는 사람이 나눔완료 버튼을 누르면 해당 음식의 상태는 즉시, 판매 완료로 전환! 이후 수정은 불가능 하기에 나눔 완료 버튼을 누르면 한번 재확인!
 - 판매완료가 이루어지면 해당 판매글을 올린 유저는 해당 게시글 삭제만 가능
 - 판매완료가 이루어지면 다른 유저는 해당 게시글에서 연락하기 버튼을 더이상 볼 수 없도록 구현
 - 삭제하기 버튼을 누르면 다시 한번 재확인하는 기능 구현
 - 상세페이지에 업로드된 날짜를 기준으로 현재일을 계산하여 언제 업로드된 게시글인지 알려주도록 Serializer변경 (업로드 날짜와 오늘의 일수 차이가 0이면 오늘, 1이면  하루전, 2부터는 2일 전으로 보여줌)